### PR TITLE
Fixing particles generated by kernels with prior probability zero

### DIFF
--- a/abcsysbio/abcsmc.py
+++ b/abcsysbio/abcsmc.py
@@ -17,7 +17,7 @@ priors:
               a 2D list.
               priors[model_number][parameter_number] is a NamedTuple of type prior.
               The .type attribute is a PriorType object (one of PriorType.constant, PriorType.uniform, PriorType.normal,
-              PriorType.lognormal, PriorType.gamma).
+              PriorType.lognormal).
               The other attributes store the appropriate parameters.
 
 fit:      
@@ -682,9 +682,6 @@ class Abcsmc:
                 if model.prior[param].type == PriorType.lognormal:
                     sample[param] = rnd.lognormal(mean=model.prior[param].mu, sigma=np.sqrt(model.prior[param].sigma))
 
-                if model.prior[param].type == PriorType.gamma:
-                    sample[param] = rnd.gamma(shape=model.prior[param].shape, scale=model.prior[param].scale)
-
             samples.append(sample[:])
 
         return samples
@@ -755,9 +752,6 @@ class Abcsmc:
             if this_prior.type == PriorType.lognormal:
                 x = statistics.get_pdf_lognormal(this_prior.mu, np.sqrt(this_prior.sigma), particle[n])
 
-            if this_prior.type == PriorType.gamma:
-                x = statistics.get_pdf_gamma(this_prior.shape, this_prior.scale, particle[n])
-
             particle_prior = particle_prior * x
         return particle_prior
 
@@ -799,9 +793,6 @@ class Abcsmc:
 
                 if this_prior.type == PriorType.lognormal:
                     x = statistics.get_pdf_lognormal(this_prior.mu, np.sqrt(this_prior.sigma), this_param[n])
-
-                if this_prior.type == PriorType.gamma:
-                    x = statistics.get_pdf_gamma(this_prior.shape, this_prior.scale, this_param[n])
 
                 particle_prior = particle_prior * x
 

--- a/abcsysbio/kernels.py
+++ b/abcsysbio/kernels.py
@@ -317,15 +317,6 @@ def get_auxilliary_info(kernel_type, models, parameters, model_objs, kernel):
                         scale = numpy.sqrt(this_kernel[2][kernel_index])
                         ret[k][param_index] = 1 - norm.cdf(0, mean, scale)
                     
-                    # if prior is gamma, trucation for the negative values
-                    # TODO: write this properly.... I just copied lines
-                    # above and changed to gamma 
-                    if this_prior[param_index].type == PriorType.gamma:
-                        shape = parameters[k][param_index]
-                        scale = numpy.sqrt(this_kernel[2][kernel_index])
-                        ret[k][param_index] = 1 - norm.cdf(0, shape, scale)
-
-
                     kernel_index += 1
         elif kernel_type == KernelType.multivariate_normal:
             up = list()
@@ -339,9 +330,6 @@ def get_auxilliary_info(kernel_type, models, parameters, model_objs, kernel):
                     low.append(-float('inf'))
                     up.append(float('inf'))
                 if this_prior[param_index].type == PriorType.lognormal:
-                    low.append(0)
-                    up.append(float('inf'))
-                if this_prior[param_index].type == PriorType.gamma:
                     low.append(0)
                     up.append(float('inf'))
                 mean.append(parameters[k][param_index])
@@ -360,9 +348,6 @@ def get_auxilliary_info(kernel_type, models, parameters, model_objs, kernel):
                     low.append(-float('inf'))
                     up.append(float('inf'))
                 if this_prior[param_index].type == PriorType.lognormal:
-                    low.append(0)
-                    up.append(float('inf'))
-                if this_prior[param_index].type == PriorType.gamma:
                     low.append(0)
                     up.append(float('inf'))
                 mean.append(parameters[k][param_index])

--- a/abcsysbio/statistics.py
+++ b/abcsysbio/statistics.py
@@ -70,6 +70,9 @@ def get_pdf_lognormal(m, sigma, x):
     sigma : standard deviation of the associated normal
     m : mean of the associated normal
     """
+    if x <= 0:
+        return 0.0
+
     x = np.exp(-0.5 * (np.log(x) - m) * (np.log(x) - m) / (sigma * sigma))
     x = x / (x * sigma * np.sqrt(2 * np.pi))
     return x

--- a/scripts/run-abc-sysbio
+++ b/scripts/run-abc-sysbio
@@ -1,4 +1,8 @@
-#!/usr/bin/python2.5
+#!/usr/bin/env python2.7
+
+import sys
+sys.path.insert (0, '../../')
+sys.path.insert (0, '../../cuda-sim/')
 
 import matplotlib
 matplotlib.use('Agg')


### PR DESCRIPTION
Points generated by kernels are supposed to have positive prior probabilities. However, kernels were generating points with probability zero. I fixed that removing the prior computations from `pertub_particle ()` 
in `kernels.py`.  Now `iterate_one_population()` uses `compute_particle_prior()` to check if a generated particle has positive prior probability. 